### PR TITLE
docs: Correct argument order in CorrelationDimension example

### DIFF
--- a/demos/Wasserstein Demo.ipynb
+++ b/demos/Wasserstein Demo.ipynb
@@ -413,7 +413,7 @@
     "# create correlation dimension object\n",
     "EMDlow, EMDhigh = 0.18, 1.15\n",
     "nbins = 61\n",
-    "corrdim = wasserstein.CorrelationDimension(EMDlow, EMDhigh, nbins)\n",
+    "corrdim = wasserstein.CorrelationDimension(nbins, EMDlow, EMDhigh)\n",
     "print(corrdim)"
    ]
   },


### PR DESCRIPTION
In https://github.com/pkomiske/Wasserstein/commit/8f4592e5a084ce935681323a93f34c0894fbc1ca for `v0.3.2` the order of arguments for `wasserstein.CorrelationDimension` was changed to have `nbins` first to

> better match boost histogram usage.

This PR applies that correction to the "Wasserstein Demo.ipynb" notebook.

As expected once one knows about this arg order change, without it the user will be met with

```pytb
TypeError: in method 'new_CorrelationDimensionFloat64', argument 1 of type 'unsigned int'
```