### PR TITLE
ci: Use 'macos-13' runs-on to continue using x86 based macOS runners

### DIFF
--- a/.github/workflows/build-wheels.yml
+++ b/.github/workflows/build-wheels.yml
@@ -29,7 +29,7 @@ jobs:
         run: pytest wasserstein
 
   macos-test:
-    runs-on: macos-latest
+    runs-on: macos-13
     steps:
       - uses: actions/checkout@v3
       - name: Setup Python
@@ -73,7 +73,7 @@ jobs:
         run: ./scripts/build-wheels-and-upload.sh sdist
 
   macos-build:
-    runs-on: macos-latest
+    runs-on: macos-13
     needs: [linux-test, macos-test, windows-test]
     steps:
       - uses: actions/checkout@v3

--- a/.github/workflows/ci.yml
+++ b/.github/workflows/ci.yml
@@ -28,7 +28,7 @@ jobs:
         os: [ubuntu-latest]
         python-version: ['3.7', '3.8', '3.9', '3.10', '3.11']
         include:
-          - os: macos-latest
+          - os: macos-13
             python-version: '3.11'
           - os: windows-latest
             python-version: '3.11'
@@ -43,7 +43,7 @@ jobs:
 
     # FIXME: Broken on modern libomp
     - name: Install libomp on macOS
-      if: matrix.os == 'macos-latest'
+      if: matrix.os == 'macos-13'
       run: |
         brew search libomp
         # brew install libomp


### PR DESCRIPTION
* The 'macos-latest' `runs-on` option has been changed to be the Apple silicon based 'macos-14' runners. To continue to use the x86 based macOS runners use 'macos-13' instead.
* This is needed as the current libomp install procedure is only valid for x86.

c.f. https://github.blog/changelog/2024-04-01-macos-14-sonoma-is-generally-available-and-the-latest-macos-runner-image/ for additional context.

Related to Issue https://github.com/thaler-lab/Wasserstein/issues/13.

Doesn't address Issue https://github.com/thaler-lab/Wasserstein/issues/15, so Windows build will fail.