### PR TITLE
build: Constrain numpy<2.0

### DIFF
--- a/setup.cfg
+++ b/setup.cfg
@@ -69,7 +69,8 @@ python_requires =
     >= 3.7
 
 install_requires =
-    numpy >= 1.12.0
+    # FIXME: https://github.com/thaler-lab/Wasserstein/issues/22
+    numpy >= 1.12.0, < 2.0.0
     wurlitzer >= 2.0.0
 
 [options.extras_require]


### PR DESCRIPTION
Addresses part of Issue #22

* NumPy v2.0 was released on 2024-06-16, tough some dependencies of Wasserstein were not ready for it. This PR adds a temporary constraint on numpy to ensure numpy v1.Y.Z is used.

~~I put these in manually instead of at the `install_requires` level~~

https://github.com/thaler-lab/Wasserstein/blob/f882b175946fd06c448e8b23151b25d50bbb54c8/setup.cfg#L71-L73

~~with the idea that this would be transitory and so not worth touching `setup.cfg`. That being said, as it would be a 1 line revert in `setup.cfg`, if this seems to be the better solution that's easy to adopt.~~