### PR TITLE
ci: Stable libomp install

### DIFF
--- a/.github/workflows/build-wheels.yml
+++ b/.github/workflows/build-wheels.yml
@@ -39,8 +39,10 @@ jobs:
           path: llvm-project
 
       - name: Build OpenMP on macOS
+        env:
+          MACOSX_DEPLOYMENT_TARGET: "10.9"
+        working-directory: llvm-project
         run: |
-          cd llvm-project
           cmake \
             -DCMAKE_BUILD_TYPE=Release \
             -DCMAKE_INSTALL_PREFIX=$(brew --prefix) \
@@ -49,11 +51,8 @@ jobs:
             -DLIBOMP_INSTALL_ALIASES=OFF \
             -S openmp \
             -B build
-          cmake \
-            --build build \
-            --parallel
+          cmake --build build --parallel
           cmake --install build
-          cd "$GITHUB_WORKSPACE"
 
       - name: Checkout Wasserstein
         uses: actions/checkout@v4

--- a/.github/workflows/build-wheels.yml
+++ b/.github/workflows/build-wheels.yml
@@ -101,21 +101,31 @@ jobs:
     runs-on: macos-13
     needs: [linux-test, macos-test, windows-test]
     steps:
-      - name: Checkout LLVM on MacOS
+      - name: Checkout LLVM on macOS
         uses: actions/checkout@v4
         with:
           repository: llvm/llvm-project
           ref: release/18.x
-      - name: Build OpenMP on MacOS
+          path: llvm-project
+
+      - name: Build OpenMP on macOS
+        env:
+          MACOSX_DEPLOYMENT_TARGET: "10.9"
+        working-directory: llvm-project
         run: |
-          cd /Users/runner/work/Wasserstein/Wasserstein/openmp
-          mkdir build
-          cd build
-          cmake -DCMAKE_BUILD_TYPE=Release -DCMAKE_INSTALL_PREFIX=$(brew --prefix) -DCMAKE_C_COMPILER=clang -DCMAKE_CXX_COMPILER=clang++ -DLIBOMP_INSTALL_ALIASES=OFF /Users/runner/work/Wasserstein/Wasserstein/openmp
-          make
-          make install
+          cmake \
+            -DCMAKE_BUILD_TYPE=Release \
+            -DCMAKE_INSTALL_PREFIX=$(brew --prefix) \
+            -DCMAKE_C_COMPILER=clang \
+            -DCMAKE_CXX_COMPILER=clang++ \
+            -DLIBOMP_INSTALL_ALIASES=OFF \
+            -S openmp \
+            -B build
+          cmake --build build --parallel
+          cmake --install build
+
       - name: Checkout Wasserstein
-        uses: actions/checkout@v3
+        uses: actions/checkout@v4
       - name: Setup Python
         uses: actions/setup-python@v4
         with:

--- a/.github/workflows/build-wheels.yml
+++ b/.github/workflows/build-wheels.yml
@@ -31,13 +31,11 @@ jobs:
   macos-test:
     runs-on: macos-13
     steps:
-      - uses: actions/checkout@v3
       - name: Checkout LLVM on MacOS
         uses: actions/checkout@v4
         with:
           repository: llvm/llvm-project
           ref: release/18.x
-
       - name: Build OpenMP on MacOS
         run: |
           cd /Users/runner/work/Wasserstein/Wasserstein/openmp
@@ -46,7 +44,6 @@ jobs:
           cmake -DCMAKE_BUILD_TYPE=Release -DCMAKE_INSTALL_PREFIX=$(brew --prefix) -DCMAKE_C_COMPILER=clang -DCMAKE_CXX_COMPILER=clang++ -DLIBOMP_INSTALL_ALIASES=OFF /Users/runner/work/Wasserstein/Wasserstein/openmp
           make
           make install
-
       - name: Checkout Wasserstein
         uses: actions/checkout@v4
       - name: Setup Python
@@ -93,7 +90,21 @@ jobs:
     runs-on: macos-13
     needs: [linux-test, macos-test, windows-test]
     steps:
-      - uses: actions/checkout@v3
+      - name: Checkout LLVM on MacOS
+        uses: actions/checkout@v4
+        with:
+          repository: llvm/llvm-project
+          ref: release/18.x
+      - name: Build OpenMP on MacOS
+        run: |
+          cd /Users/runner/work/Wasserstein/Wasserstein/openmp
+          mkdir build
+          cd build
+          cmake -DCMAKE_BUILD_TYPE=Release -DCMAKE_INSTALL_PREFIX=$(brew --prefix) -DCMAKE_C_COMPILER=clang -DCMAKE_CXX_COMPILER=clang++ -DLIBOMP_INSTALL_ALIASES=OFF /Users/runner/work/Wasserstein/Wasserstein/openmp
+          make
+          make install
+      - name: Checkout Wasserstein
+        uses: actions/checkout@v3
       - name: Setup Python
         uses: actions/setup-python@v4
         with:

--- a/.github/workflows/build-wheels.yml
+++ b/.github/workflows/build-wheels.yml
@@ -32,6 +32,23 @@ jobs:
     runs-on: macos-13
     steps:
       - uses: actions/checkout@v3
+      - name: Checkout LLVM on MacOS
+        uses: actions/checkout@v4
+        with:
+          repository: llvm/llvm-project
+          ref: release/18.x
+
+      - name: Build OpenMP on MacOS
+        run: |
+          cd /Users/runner/work/Wasserstein/Wasserstein/openmp
+          mkdir build
+          cd build
+          cmake -DCMAKE_BUILD_TYPE=Release -DCMAKE_INSTALL_PREFIX=$(brew --prefix) -DCMAKE_C_COMPILER=clang -DCMAKE_CXX_COMPILER=clang++ -DLIBOMP_INSTALL_ALIASES=OFF /Users/runner/work/Wasserstein/Wasserstein/openmp
+          make
+          make install
+
+      - name: Checkout Wasserstein
+        uses: actions/checkout@v4
       - name: Setup Python
         uses: actions/setup-python@v4
         with:

--- a/.github/workflows/build-wheels.yml
+++ b/.github/workflows/build-wheels.yml
@@ -31,19 +31,30 @@ jobs:
   macos-test:
     runs-on: macos-13
     steps:
-      - name: Checkout LLVM on MacOS
+      - name: Checkout LLVM on macOS
         uses: actions/checkout@v4
         with:
           repository: llvm/llvm-project
           ref: release/18.x
-      - name: Build OpenMP on MacOS
+          path: llvm-project
+
+      - name: Build OpenMP on macOS
         run: |
-          cd /Users/runner/work/Wasserstein/Wasserstein/openmp
-          mkdir build
-          cd build
-          cmake -DCMAKE_BUILD_TYPE=Release -DCMAKE_INSTALL_PREFIX=$(brew --prefix) -DCMAKE_C_COMPILER=clang -DCMAKE_CXX_COMPILER=clang++ -DLIBOMP_INSTALL_ALIASES=OFF /Users/runner/work/Wasserstein/Wasserstein/openmp
-          make
-          make install
+          cd llvm-project
+          cmake \
+            -DCMAKE_BUILD_TYPE=Release \
+            -DCMAKE_INSTALL_PREFIX=$(brew --prefix) \
+            -DCMAKE_C_COMPILER=clang \
+            -DCMAKE_CXX_COMPILER=clang++ \
+            -DLIBOMP_INSTALL_ALIASES=OFF \
+            -S openmp \
+            -B build
+          cmake \
+            --build build \
+            --parallel
+          cmake --install build
+          cd "$GITHUB_WORKSPACE"
+
       - name: Checkout Wasserstein
         uses: actions/checkout@v4
       - name: Setup Python

--- a/.github/workflows/build-wheels.yml
+++ b/.github/workflows/build-wheels.yml
@@ -60,8 +60,6 @@ jobs:
         uses: actions/setup-python@v4
         with:
           python-version: '3.9'
-      - name: Compile and install libomp from source
-        run: ./scripts/install-libomp-macos.sh
       - name: Install Python packages
         run: |
           python3 -m pip install --extra-index-url https://test.pypi.org/simple energyflow==1.3.3a0
@@ -129,8 +127,6 @@ jobs:
         uses: actions/setup-python@v4
         with:
           python-version: '3.9'
-      - name: Compile and install libomp from source
-        run: ./scripts/install-libomp-macos.sh
       - name: Build wheels and upload to PyPI
         run: ./scripts/build-wheels-and-upload.sh
 

--- a/.github/workflows/ci.yml
+++ b/.github/workflows/ci.yml
@@ -41,13 +41,30 @@ jobs:
       with:
         python-version: ${{ matrix.python-version }}
 
-    # FIXME: Broken on modern libomp
-    - name: Install libomp on macOS
+    - name: Checkout LLVM on macOS
       if: matrix.os == 'macos-13'
+      uses: actions/checkout@v4
+      with:
+        repository: llvm/llvm-project
+        ref: release/18.x
+        path: llvm-project
+
+    - name: Build OpenMP on macOS
+      if: matrix.os == 'macos-13'
+      env:
+        MACOSX_DEPLOYMENT_TARGET: "10.9"
+      working-directory: llvm-project
       run: |
-        brew search libomp
-        # brew install libomp
-        bash ./scripts/install-libomp-macos.sh
+        cmake \
+          -DCMAKE_BUILD_TYPE=Release \
+          -DCMAKE_INSTALL_PREFIX=$(brew --prefix) \
+          -DCMAKE_C_COMPILER=clang \
+          -DCMAKE_CXX_COMPILER=clang++ \
+          -DLIBOMP_INSTALL_ALIASES=OFF \
+          -S openmp \
+          -B build
+        cmake --build build --parallel
+        cmake --install build
 
     - name: Install dependencies
       run: |


### PR DESCRIPTION
Resolves #19 ~~, addresses the following items from #10~~
~~> [build-wheels.yml](https://github.com/thaler-lab/Wasserstein/blob/master/.github/workflows/build-wheels.yml)~~
~~> - [ ] Remove test jobs~~
~~> - [ ] Use GHA cibuildwheel instead of build-wheel script~~
~~> - [ ] Use GHA pypa/publish~~

For MacOS builds (currently just MacOS-13), this will:
1. [Use the GH checkout action to access the entire LLVM project](https://github.com/j-s-ashley/Wasserstein/blob/fix/libomp-install/.github/workflows/build-wheels.yml#L29)
2. [Build and install OpenMP with appropriate compiler flags](https://github.com/j-s-ashley/Wasserstein/blob/fix/libomp-install/.github/workflows/build-wheels.yml#L36)