### PR TITLE
fix: Remove numpy install from build wheel script env

### DIFF
--- a/scripts/build-wheels-and-upload.sh
+++ b/scripts/build-wheels-and-upload.sh
@@ -2,8 +2,8 @@
 
 echo "Preparing to upload to PyPI ..."
 
-echo "Installing cibuildwheel, twine, and numpy ..."
-python3 -m pip install cibuildwheel twine numpy
+echo "Installing cibuildwheel and twine..."
+python3 -m pip install cibuildwheel twine
 
 echo "Building wheels ..."
 python3 -m cibuildwheel --output-dir wheelhouse

--- a/scripts/build-wheels-and-upload.sh
+++ b/scripts/build-wheels-and-upload.sh
@@ -9,9 +9,9 @@ echo "Building wheels ..."
 python3 -m cibuildwheel --output-dir wheelhouse
 
 # upload to test server
-if [ $PYPITEST -gt 0 ]; then
+if [[ $PYPITEST -gt 0 ]]; then
   export TWINE_PASSWORD=$TWINE_PASSWORD_PYPITEST
-  if [ "$1" = "sdist" ]; then
+  if [[ "$1" = "sdist" ]]; then
     python3 setup.py sdist --formats=gztar
     python3 -m twine upload -r testpypi --skip-existing --verbose dist/*.tar.gz
   fi
@@ -19,9 +19,9 @@ if [ $PYPITEST -gt 0 ]; then
 fi
 
 # upload to real pypi server
-if [ $PYPI -gt 0 ]; then
+if [[ $PYPI -gt 0 ]]; then
   export TWINE_PASSWORD=$TWINE_PASSWORD_PYPI
-  if [ "$1" = "sdist" ]; then
+  if [[ "$1" = "sdist" ]]; then
     python3 setup.py sdist --formats=gztar
     python3 -m twine upload --skip-existing --verbose dist/*.tar.gz
   fi


### PR DESCRIPTION
* NumPy should not be installed manually but as a build dependency it should be defined in the build-system requires in pyproject.toml.
* Amends PR #23
* Compliments PR https://github.com/thaler-lab/Wasserstein/pull/24 (should go in before PR #24 does and have PR #24 get rebased on top). This PR won't fix the `delocate-wheel` error that is being seen in the macOS wheel building, but it is a bit that needs to get cleaned along with PR #25, and PR #24.