### PR TITLE
build: Normalize library name to lowercase

### DIFF
--- a/setup.cfg
+++ b/setup.cfg
@@ -1,6 +1,5 @@
 [metadata]
-
-name = Wasserstein
+name = wasserstein
 description = Python package wrapping C++ code for computing Wasserstein distances
 
 author = Patrick T. Komiske III


### PR DESCRIPTION
* Using uppercase library names causes unnecessary challenges when comparing sdist and wheels.

e.g. on `master` at 0a0fdeb810fc6f6b55fe773ea75fef7febb02047:

```console
$ rm -rf dist && pipx run build --installer uv . && ls -lh dist/
Successfully built wasserstein-1.1.0.tar.gz and Wasserstein-1.1.0-cp312-cp312-linux_x86_64.whl
total 756K
-rw-rw-r-- 1 feickert feickert 367K Jun 19 01:25 Wasserstein-1.1.0-cp312-cp312-linux_x86_64.whl
-rw-rw-r-- 1 feickert feickert 388K Jun 19 01:25 wasserstein-1.1.0.tar.gz
```

vs. this PR

```console
$ rm -rf dist && pipx run build --installer uv . && ls -lh dist/
Successfully built wasserstein-1.1.0.tar.gz and wasserstein-1.1.0-cp312-cp312-linux_x86_64.whl
total 760K
-rw-rw-r-- 1 feickert feickert 367K Jun 19 01:26 wasserstein-1.1.0-cp312-cp312-linux_x86_64.whl
-rw-rw-r-- 1 feickert feickert 389K Jun 19 01:26 wasserstein-1.1.0.tar.gz
```