### PR TITLE
build: Disallow scipy v1.14.0

### DIFF
--- a/setup.cfg
+++ b/setup.cfg
@@ -77,5 +77,7 @@ install_requires =
 test =
     energyflow
     pot
+    # FIXME: https://github.com/thaler-lab/Wasserstein/issues/36
+    scipy!=1.14.0
     pytest
     coverage


### PR DESCRIPTION
Resolves #36 

* Until POT fixes its use of `from scipy.optimize import scalar_search_armijo` which is broken by SciPy v1.14.0+, disallow install of scipy v1.14.0.