### PR TITLE
ci: Install with '--upgrade' to ensure constraints take priority

### DIFF
--- a/.github/workflows/build-wheels.yml
+++ b/.github/workflows/build-wheels.yml
@@ -24,7 +24,7 @@ jobs:
       - name: Install Python packages
         run: |
           python3 -m pip install --extra-index-url https://test.pypi.org/simple energyflow==1.3.3a0
-          python3 -m pip install .[test] pytest
+          python3 -m pip install --upgrade ".[test]" pytest
       - name: Test package
         run: pytest tests
 
@@ -63,7 +63,7 @@ jobs:
       - name: Install Python packages
         run: |
           python3 -m pip install --extra-index-url https://test.pypi.org/simple energyflow==1.3.3a0
-          python3 -m pip install .[test] pytest
+          python3 -m pip install --upgrade ".[test]" pytest
       - name: Test package
         run: pytest tests
 
@@ -78,7 +78,7 @@ jobs:
       - name: Install Python packages
         run: |
           python3 -m pip install --extra-index-url https://test.pypi.org/simple energyflow==1.3.3a0
-          python3 -m pip install .[test] pytest
+          python3 -m pip install --upgrade ".[test]" pytest
       - name: Test package
         run: pytest tests
 


### PR DESCRIPTION
* Use `pip install --upgrade ".[test]"` to install the package and its dependencies so that any constraints that exist will take priority over installed packages.

Amends PR #38 