### PR TITLE
Add manual trigger to workflow

### DIFF
--- a/.github/workflows/build-wheels.yml
+++ b/.github/workflows/build-wheels.yml
@@ -4,6 +4,7 @@ on:
   push:
     branches:
       - master
+  workflow_dispatch:
 
 env:
   PYPI: 1


### PR DESCRIPTION
[Wasserstein's build-wheels.yaml workflow](https://github.com/thaler-lab/Wasserstein/blob/master/.github/workflows/build-wheels.yml) does not have a `workflow_dispatch` trigger, making tests mildly inconvenient. 