### PR TITLE
build: Add support for NumPy 2.0 wheels

### DIFF
--- a/pyproject.toml
+++ b/pyproject.toml
@@ -1,7 +1,8 @@
 [build-system]
 requires = [
     "setuptools>=42",
-    "oldest-supported-numpy",
+    "oldest-supported-numpy; python_version < '3.9'",
+    "numpy>=2.0.0; python_version >= '3.9'",
 ]
 build-backend = "setuptools.build_meta"
 

--- a/setup.cfg
+++ b/setup.cfg
@@ -68,8 +68,7 @@ python_requires =
     >= 3.7
 
 install_requires =
-    # FIXME: https://github.com/thaler-lab/Wasserstein/issues/22
-    numpy >= 1.12.0, < 2.0.0
+    numpy >= 1.12.0
     wurlitzer >= 2.0.0
 
 [options.extras_require]

--- a/wasserstein/swig/wasserstein.i
+++ b/wasserstein/swig/wasserstein.i
@@ -116,7 +116,7 @@ def _store_events(pairwise_emd, events, event_weights, gdim, mask, dtype):
         # sometimes, e.g. in the case of a single particle, they may not
         # weights are never modified due to internal copying
         # coords may be modified (e.g. by centering), so we always make a copy of them
-        weights = np.array(event[:,0], dtype=dtype, order='C', copy=False)
+        weights = np.asarray(event[:,0], dtype=dtype, order='C')
         coords = np.array(event[:,1:], dtype=dtype, order='C', copy=True)
 
         # ensure that the lifetime of these arrays lasts through the computation

--- a/wasserstein/wasserstein.py
+++ b/wasserstein/wasserstein.py
@@ -842,7 +842,7 @@ def _store_events(pairwise_emd, events, event_weights, gdim, mask, dtype):
 # sometimes, e.g. in the case of a single particle, they may not
 # weights are never modified due to internal copying
 # coords may be modified (e.g. by centering), so we always make a copy of them
-        weights = np.array(event[:,0], dtype=dtype, order='C', copy=False)
+        weights = np.asarray(event[:,0], dtype=dtype, order='C')
         coords = np.array(event[:,1:], dtype=dtype, order='C', copy=True)
 
 # ensure that the lifetime of these arrays lasts through the computation


### PR DESCRIPTION
Resolves #22 

* Add numpy>=2.0.0 to build-system requires to build NumPy 1.x and 2.x compatible wheels.
   - c.f. https://numpy.org/doc/stable/dev/depending_on_numpy.html#numpy-2-0-specific-advice
   - As NumPy 2.0 is Python 3.9+, also need to conditionally support 'oldest-supported-numpy' for Python 3.8 and older.
* Remove upper bound on numpy version as POT v0.9.4 supports NumPy v2.0 wheels.
   - c.f. https://github.com/PythonOT/POT/releases/tag/0.9.4
* Use NumPy 2.0 copy for arrays via asarray
   - Use numpy.asarray as already dealing with array-like data.
   - Remove the copy kwarg as for NumPy 2.0 the default is None which makes a copy only if needed:

     > If None then the object is copied only if needed, i.e. if
     > __array__ returns a copy, if obj is a nested sequence, or if a copy is
     > needed to satisfy any of the other requirements (dtype, order, etc.).

     In NumPy 1.26 numpy.asarray, NumPy will try to avoid a copy if possible

     > No copy is performed if the input is already an ndarray with matching
     > dtype and order.