### PR TITLE
revert: Remove disallow of scipy v1.14.0

### DIFF
--- a/pyproject.toml
+++ b/pyproject.toml
@@ -11,7 +11,7 @@ skip = "pp* *musllinux*"
 test-skip = "*i686 *win32 *-macosx_arm64"
 before-test = "pip install cython; pip install --extra-index-url https://test.pypi.org/simple energyflow==1.3.3a0"
 test-command = "pytest {package}"
-test-requires = ["pytest", "numpy", "pot", "energyflow", "scipy!=1.14.0"]
+test-requires = ["pytest", "numpy", "pot", "energyflow"]
 
 #FIXME delete with closure of https://github.com/thaler-lab/Wasserstein/issues/13
 [tool.cibuildwheel.macos]

--- a/setup.cfg
+++ b/setup.cfg
@@ -77,7 +77,5 @@ install_requires =
 test =
     energyflow
     pot
-    # FIXME: https://github.com/thaler-lab/Wasserstein/issues/36
-    scipy!=1.14.0
     pytest
     coverage


### PR DESCRIPTION
* With the release of POT v0.9.4, scipy v1.14.0 can be used.
   - c.f. https://github.com/PythonOT/POT/releases/tag/0.9.4
* Reverts PR #38 
* Reverts guard from PR #26