### PR TITLE
ci: Install EnergyFlow from GitHub HEAD

### DIFF
--- a/.github/workflows/ci.yml
+++ b/.github/workflows/ci.yml
@@ -69,8 +69,10 @@ jobs:
     - name: Install dependencies
       run: |
         python -m pip install --upgrade pip setuptools wheel
-        python -m pip install --upgrade --extra-index-url https://test.pypi.org/simple "energyflow==1.3.3a0"
         python -m pip install --upgrade ".[test]"
+        # FIXME: c.f. https://github.com/thaler-lab/Wasserstein/issues/46
+        python -m pip uninstall --yes EnergyFlow
+        python -m pip install "git+https://github.com/thaler-lab/EnergyFlow.git"
 
     - name: List installed Python packages
       run: python -m pip list

--- a/pyproject.toml
+++ b/pyproject.toml
@@ -10,7 +10,7 @@ build-backend = "setuptools.build_meta"
 [tool.cibuildwheel]
 skip = "pp* *musllinux*"
 test-skip = "*i686 *win32 *-macosx_arm64"
-before-test = "pip install cython; pip install --extra-index-url https://test.pypi.org/simple energyflow==1.3.3a0"
+before-test = "pip install cython; pip install git+https://github.com/thaler-lab/EnergyFlow.git"
 test-command = "pytest {package}"
 test-requires = ["pytest", "numpy", "pot", "energyflow"]
 


### PR DESCRIPTION
* Install the development HEAD of EnergyFlow from GitHub to be able to test changes made to it until a stable release is reached.
* Partially addresses Issue https://github.com/thaler-lab/Wasserstein/issues/46.