### PR TITLE
ci: Add dependabot

### DIFF
--- a/.github/dependabot.yml
+++ b/.github/dependabot.yml
@@ -1,0 +1,11 @@
+version: 2
+updates:
+  # Maintain dependencies for GitHub Actions
+  - package-ecosystem: "github-actions"
+    directory: "/"
+    schedule:
+      interval: "weekly"
+    groups:
+      actions:
+        patterns:
+          - "*"


### PR DESCRIPTION
Implements automatic updates for non-standard GitHub Actions.

See the [Scientific Python Development Guide](https://learn.scientific-python.org/development/guides/gha-basic/#updating) for more information.