### PR TITLE
ci: Add Python 3.12 to builds

### DIFF
--- a/.github/workflows/ci.yml
+++ b/.github/workflows/ci.yml
@@ -26,14 +26,14 @@ jobs:
     strategy:
       matrix:
         os: [ubuntu-latest]
-        python-version: ['3.7', '3.8', '3.9', '3.10', '3.11']
+        python-version: ['3.7', '3.8', '3.9', '3.10', '3.11', '3.12']
         include:
           - os: macos-13
-            python-version: '3.11'
+            python-version: '3.12'
           - os: macos-latest
-            python-version: '3.11'
+            python-version: '3.12'
           - os: windows-latest
-            python-version: '3.11'
+            python-version: '3.12'
 
     steps:
     - uses: actions/checkout@v4


### PR DESCRIPTION
Resolves the Python 3.12 part of Issue https://github.com/thaler-lab/Wasserstein/issues/55. Python 3.13 will need to wait as there aren't wheels out for all of the test dependencies of `wasserstein` yet.

With regards to the

> ... and add classifiers

that can happen post PR https://github.com/thaler-lab/Wasserstein/pull/54 getting merged.