### PR TITLE
ci: Skip Python 3.13 wheel building

### DIFF
--- a/pyproject.toml
+++ b/pyproject.toml
@@ -89,8 +89,7 @@ wheel.exclude = [
     "**.i"]
 
 [tool.cibuildwheel]
-skip = "pp* *musllinux*"
-test-skip = "*i686 *win32 *-macosx_arm64"
+skip = "pp* *musllinux* cp313-*"
 before-test = "pip install cython; pip install git+https://github.com/thaler-lab/EnergyFlow.git"
 test-command = "pytest {package}"
 test-requires = ["pytest", "numpy", "pot", "energyflow"]


### PR DESCRIPTION
* Skip building Python 3.13 wheels for the time being as POT doesn't currenly support it and POT is required for tests.
* Remove test-skips.