### PR TITLE
ci: Use energyflow v1.3.4+ for testing

### DIFF
--- a/.github/workflows/ci.yml
+++ b/.github/workflows/ci.yml
@@ -79,19 +79,13 @@ jobs:
     - name: Install dependencies
       if: matrix.python-version == '3.7'
       run: |
-        python -m pip install --upgrade pip setuptools wheel
+        python -m pip install --upgrade pip
         python -m pip install --upgrade ".[test]"
-        # FIXME: c.f. https://github.com/thaler-lab/Wasserstein/issues/46
-        python -m pip uninstall --yes EnergyFlow
-        python -m pip install "git+https://github.com/thaler-lab/EnergyFlow.git"
 
     - name: Install dependencies
       if: matrix.python-version != '3.7'
       run: |
         uv pip install --system --upgrade ".[test]"
-        # FIXME: c.f. https://github.com/thaler-lab/Wasserstein/issues/46
-        uv pip uninstall --system EnergyFlow
-        uv pip install --system "git+https://github.com/thaler-lab/EnergyFlow.git"
 
     - name: List installed Python packages
       run: python -m pip list

--- a/pyproject.toml
+++ b/pyproject.toml
@@ -68,7 +68,7 @@ dependencies = [
 [project.optional-dependencies]
 test = [
     "coverage",
-    "energyflow",
+    "energyflow >= 1.3.4",
     "pot",
     "pytest",
 ]
@@ -90,6 +90,6 @@ wheel.exclude = [
 
 [tool.cibuildwheel]
 skip = "pp* *musllinux* cp313-*"
-before-test = "pip install cython; pip install git+https://github.com/thaler-lab/EnergyFlow.git"
+before-test = "pip install cython"
 test-command = "pytest {package}"
 test-requires = ["pytest", "numpy", "pot", "energyflow"]


### PR DESCRIPTION
Resolves #46 

* Use the energyflow v1.3.4 or later for testing and builds.
   - c.f. https://github.com/thaler-lab/EnergyFlow/releases/tag/v1.3.4
* Remove of energyflow from GitHub.