### PR TITLE
build: Generate version from VCS

### DIFF
--- a/.github/workflows/build-wheels.yml
+++ b/.github/workflows/build-wheels.yml
@@ -15,6 +15,8 @@ jobs:
     runs-on: ubuntu-latest
     steps:
       - uses: actions/checkout@v4
+        with:
+          fetch-depth: 0
 
       - name: Build SDist
         run: pipx run build --sdist
@@ -60,6 +62,8 @@ jobs:
 
       - name: Checkout Wasserstein repo
         uses: actions/checkout@v4
+        with:
+          fetch-depth: 0
 
       - name: cibw-wheel
         uses: pypa/cibuildwheel@v2.21

--- a/.github/workflows/ci.yml
+++ b/.github/workflows/ci.yml
@@ -37,6 +37,8 @@ jobs:
 
     steps:
     - uses: actions/checkout@v4
+      with:
+        fetch-depth: 0
 
     - name: Set up Python ${{ matrix.python-version }}
       uses: actions/setup-python@v5

--- a/pyproject.toml
+++ b/pyproject.toml
@@ -9,7 +9,7 @@ build-backend = "scikit_build_core.build"
 
 [project]
 name = "wasserstein"
-version = "1.1.0"
+dynamic = ["version"]
 description = "Python package wrapping C++ code for computing Wasserstein distances"
 readme = "README.md"
 license.file = "LICENSE"
@@ -87,6 +87,19 @@ cmake.version = ">=3.20"
 wheel.exclude = [
     "**.hh",
     "**.i"]
+metadata.version.provider = "scikit_build_core.metadata.setuptools_scm"
+build.verbose = true
+logging.level = "INFO"
+
+[tool.setuptools_scm]
+# Ignore the commit hash in version
+local_scheme = "no-local-version"
+
+[[tool.scikit-build.generate]]
+path = "wasserstein/_version.py"
+template = '''
+version = "${version}"
+'''
 
 [tool.cibuildwheel]
 skip = "pp* *musllinux* cp313-*"

--- a/src/wasserstein/__init__.py
+++ b/src/wasserstein/__init__.py
@@ -37,18 +37,12 @@ $$  /   \$$ |\$$$$$$$ |$$$$$$$  |$$$$$$$  |\$$$$$$$\ $$ |      $$$$$$$  |  \$$$$
 ------------------------------------------------------------------------
 """
 
-# basic package info
-__author__  = 'Patrick T. Komiske III'
-__email__   = 'pkomiske@gmail.com'
-__license__ = 'GPLv3'
-__version__ = '1.1.0'
-
-from . import config
-from .config import *
+from wasserstein import config
+from wasserstein.config import *
+from wasserstein._version import version as __version__
 
 # these are all attributes of wasserstein submodule that should be top-level visible
 __all__ = [
-
     # primary functionality with variable dtype
     'EMD', 'EMDYPhi',
     'PairwiseEMD', 'PairwiseEMDYPhi',
@@ -90,7 +84,7 @@ __all__ = [
 # enables lazy importing of wasserstein submodule
 def __getattr__(name):
     if name in __all__:
-        from . import wasserstein
+        from wasserstein import wasserstein
         attr = getattr(wasserstein, name)
         globals()[name] = attr
         return attr
@@ -98,9 +92,9 @@ def __getattr__(name):
     # handle specially grabbing the submodule
     elif name == 'wasserstein':
         import importlib
-        wasserstein = importlib.import_module('.wasserstein', __name__)
-        globals()['wasserstein'] = wasserstein
-        return wasserstein
+        _wasserstein = importlib.import_module('wasserstein.wasserstein')
+        globals()['wasserstein'] = _wasserstein
+        return _wasserstein
 
     raise AttributeError(f'module `{__name__}` has no attribute `{name}`')
 
@@ -109,9 +103,6 @@ def __dir__():
     return __all__ + [
         'wasserstein',
         'config',
-        '__author__',
-        '__email__',
-        '__license__',
         '__version__',
         '__doc__',
         '__name__',


### PR DESCRIPTION
* Use scikit_build_core.metadata.setuptools_scm to generate the version information and file from the version control system at build time.
* Clone the entire repository during CI to get all tag information to correctly determine version at build.