### PR TITLE
build: Prefer binary installs in cibuildwheel options

### DIFF
--- a/pyproject.toml
+++ b/pyproject.toml
@@ -102,7 +102,11 @@ version = "${version}"
 '''
 
 [tool.cibuildwheel]
+build-frontend = "build[uv]"
 skip = "pp* *musllinux* cp313-*"
 before-test = "pip install cython"
-test-command = "pytest {package}"
+test-extras = "test"
+test-command = "pytest {project}/tests"
 test-requires = ["pytest", "numpy", "pot", "energyflow"]
+environment.PIP_ONLY_BINARY = "numpy"
+environment.PIP_PREFER_BINARY = "1"


### PR DESCRIPTION
Resolves #66 

* Enable PIP_PREFER_BINARY to ensure wheels are used if possible.
* Use 'build[uv]' as build frontend to speed up installs when possible.
* Revise the test command to explicitly target the tests/ directory.